### PR TITLE
feat: allow compose generator to scan root

### DIFF
--- a/scripts/gen-compose.py
+++ b/scripts/gen-compose.py
@@ -3,7 +3,13 @@ import os, json, re, sys, yaml
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+# Service folders may live directly under the repo root in some distributions
+# or inside a dedicated "services" directory.  Fall back to the root if the
+# "services" folder is missing so the generator still works.
 SERVICES = ROOT / "services"
+if not SERVICES.exists():
+    SERVICES = ROOT
+
 OUT = ROOT / "docker-compose.integrated.yml"
 GLOBAL_ENV = ROOT / ".env.global"
 


### PR DESCRIPTION
## Summary
- permit `scripts/gen-compose.py` to look for services directly under repo root when `services/` folder is absent

## Testing
- `python3 scripts/gen-compose.py`


------
https://chatgpt.com/codex/tasks/task_e_689f9fbbb27c8321bccb77769d713444