### PR TITLE
Clean up unused imports and auth middleware

### DIFF
--- a/P7-payments/assetarc-payments/app.py
+++ b/P7-payments/assetarc-payments/app.py
@@ -1,6 +1,6 @@
 
-import os, json, tempfile, datetime
-from flask import Flask, request, jsonify, send_file
+import os, tempfile, datetime
+from flask import Flask, request, jsonify
 from flask_cors import CORS
 from dotenv import load_dotenv
 from sqlalchemy import text as sql

--- a/P8-booking/assetarc-booking/auth_middleware.py
+++ b/P8-booking/assetarc-booking/auth_middleware.py
@@ -20,7 +20,6 @@ def current_user():
     except Exception:
         return None
 def require_auth(fn):
-    from functools import wraps
     @wraps(fn)
     def _w(*a, **k):
         u=current_user()


### PR DESCRIPTION
## Summary
- remove redundant inner `wraps` import in booking auth middleware
- drop unused imports in payments app

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pyflakes P8-booking/assetarc-booking/auth_middleware.py P7-payments/assetarc-payments/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689fa4b5257483218b2d54c1a284ec94