### PR TITLE
Fix NOWPayments env variable names

### DIFF
--- a/P7-payments-full/assetarc-payments/.env.example
+++ b/P7-payments-full/assetarc-payments/.env.example
@@ -1,0 +1,9 @@
+# Example environment configuration for AssetArc Payments service
+JWT_SECRET=change_me
+ACCESS_COOKIE=access_token
+NOWPAYMENTS_API_KEY=
+NOWPAYMENTS_IPN_SECRET=
+YOCO_WEBHOOK_SECRET=
+TOKENS_BASE=http://tokens.asset-arc.local
+TOKENS_INTERNAL_KEY=change_me_internal_secret
+CORS_ALLOWED_ORIGINS=

--- a/P7-payments-full/assetarc-payments/README.md
+++ b/P7-payments-full/assetarc-payments/README.md
@@ -14,9 +14,14 @@ Purpose:
 - `POST /webhook/yoco` – confirm card payments (mints token)
 
 ## Quickstart
-1) `cp .env.example .env` and set keys.
+1) `cp .env.example .env` and set keys (`NOWPAYMENTS_API_KEY`, `NOWPAYMENTS_IPN_SECRET`, etc.).
 2) `pip install -r requirements.txt`
 3) `flask --app app.py run --host 0.0.0.0 --port 5011 --debug`
+
+## Environment Variables
+- `NOWPAYMENTS_API_KEY` – API key for creating invoices.
+- `NOWPAYMENTS_IPN_SECRET` – secret for validating NOWPayments webhooks.
+- `YOCO_WEBHOOK_SECRET` – optional secret to verify Yoco webhook signatures.
 
 ## Notes
 - **Yoco**: this pack processes webhooks. Creating payment links/sessions can be done client- or server-side; integrate your preferred Yoco flow on the frontend. Webhook confirmation here will mint tokens.

--- a/P7-payments-full/assetarc-payments/app.py
+++ b/P7-payments-full/assetarc-payments/app.py
@@ -12,8 +12,8 @@ CORS(app, resources={r"/*":{"origins":[o.strip() for o in os.getenv('CORS_ALLOWE
 JWT_SECRET=os.getenv('JWT_SECRET','change_me')
 ACCESS_COOKIE=os.getenv('ACCESS_COOKIE','access_token')
 
-NOW_API=os.getenv('NOWPAY_API_KEY','')
-NOW_IPN_SECRET=os.getenv('NOWPAY_IPN_SECRET','')
+NOW_API=os.getenv('NOWPAYMENTS_API_KEY', '')
+NOW_IPN_SECRET=os.getenv('NOWPAYMENTS_IPN_SECRET', '')
 YOCO_WH=os.getenv('YOCO_WEBHOOK_SECRET','')
 
 TOK_BASE=os.getenv('TOKENS_BASE','http://tokens.asset-arc.local')


### PR DESCRIPTION
## Summary
- correct NOWPayments API key and IPN secret environment variable lookups
- add example env file and document required variables

## Testing
- `ruff check P7-payments-full/assetarc-payments` *(fails: E401, E701)*

------
https://chatgpt.com/codex/tasks/task_e_68a04cd4e8a083218ad50e0a7871badd