### PR TITLE
Handle empty CSV export in review service

### DIFF
--- a/P09-review/assetarc-review/db.py
+++ b/P09-review/assetarc-review/db.py
@@ -29,10 +29,24 @@ def init_db():
 
 def export_csv(table: str, rows: list[dict]):
     os.makedirs('exports', exist_ok=True)
-    path=f'exports/{table}.csv'
+    path = f'exports/{table}.csv'
+
+    # When there are no rows, ensure we either create an empty CSV with
+    # headers or simply return without attempting to access ``rows[0]``.
+    if not rows:
+        if not os.path.exists(path):
+            with _engine.connect() as c:
+                result = c.execute(text(f'SELECT * FROM {table} LIMIT 0'))
+                fieldnames = result.keys()
+            with open(path, 'w', newline='', encoding='utf-8') as f:
+                csv.DictWriter(f, fieldnames=fieldnames).writeheader()
+        return path
+
     new = not os.path.exists(path)
     with open(path, 'a', newline='', encoding='utf-8') as f:
-        w=csv.DictWriter(f, fieldnames=rows[0].keys())
-        if new: w.writeheader()
-        for r in rows: w.writerow(r)
+        w = csv.DictWriter(f, fieldnames=rows[0].keys())
+        if new:
+            w.writeheader()
+        for r in rows:
+            w.writerow(r)
     return path

--- a/P09-review/assetarc-review/test_db.py
+++ b/P09-review/assetarc-review/test_db.py
@@ -1,0 +1,19 @@
+import os
+import csv
+from pathlib import Path
+
+import db
+
+
+def test_export_csv_empty_rows(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        db.init_db()
+        path = db.export_csv('flags', [])
+        assert Path(path).exists()
+        with open(path, newline='', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            assert list(reader) == []
+    finally:
+        os.chdir(cwd)


### PR DESCRIPTION
## Summary
- handle empty row exports in `export_csv` by early return and optional header-only file creation
- add regression test for empty `export_csv('flags', [])`

## Testing
- `pytest P09-review/assetarc-review/test_db.py`


------
https://chatgpt.com/codex/tasks/task_e_68a04ed0fb308321b790d416d7b80a56