### PR TITLE
docs: clarify signed url filename option

### DIFF
--- a/P04-vault/assetarc-vault/README.md
+++ b/P04-vault/assetarc-vault/README.md
@@ -1,16 +1,30 @@
-
 # AssetArc – S3 Vault & Document Service
 
-Stores originals in S3 with versioning, generates **watermarked previews**, tracks downloads, and issues short-lived **signed URLs**. Before human review approval, only the preview is visible. After approval, original can be downloaded via signed link.
+Stores originals in S3 with versioning, generates **watermarked previews**, tracks
+downloads, and issues short-lived **signed URLs**. Before human review approval,
+only the preview is visible. After approval, original can be downloaded via signed
+link.
 
 ## Endpoints
+
 - `GET  /healthz`
 - `POST /files/upload` (multipart: `file`), optional fields: `folder`, `label`
 - `GET  /files` – list my files
 - `GET  /files/<id>` – metadata
 - `POST /files/<id>/watermark` – generate/update preview (PDF/image)
 - `POST /files/<id>/approve` – mark approved
-- `POST /files/<id>/signed-url` – `{disposition?: "inline"|"attachment"}` → presigned S3 URL
+- `POST /files/<id>/signed-url` –
+  `{disposition?: "inline"|"attachment", filename?: string}`
+  → presigned S3 URL
+  Example:
+
+  ```json
+  {
+    "disposition": "attachment",
+    "filename": "contract.pdf"
+  }
+  ```
+
 - `POST /files/<id>/track-download` – record a download event
 
 Auth: JWT cookie/header shared with Auth (Project 1).


### PR DESCRIPTION
## Summary
- document `filename` option alongside `disposition` for `/files/<id>/signed-url`
- add JSON example payload for signed-url request
- format README and check markdown lint

## Testing
- `npx prettier -w P04-vault/assetarc-vault/README.md`
- `npx -y markdownlint-cli P04-vault/assetarc-vault/README.md`

------
https://chatgpt.com/codex/tasks/task_e_68a0508307408321a363b3d00f5ccac4