### PR TITLE
Use folder parameter in vault file insert queries

### DIFF
--- a/P04-vault/assetarc-vault/app.py
+++ b/P04-vault/assetarc-vault/app.py
@@ -46,8 +46,8 @@ def upload():
     key=f"{email}/{folder}/{int(datetime.utcnow().timestamp())}_{f.filename}"
     put_object(key, data, content_type)
     s=Session()
-    s.execute(sql('INSERT INTO files(owner_email,label,folder,s3_key,sha256,content_type,size_bytes,approved,version) VALUES (:e,:l,:fo,:k,:sha,:ct,:sz,0,1)'),
-              {'e':email,'l':label,'fo':folder,'k':key,'sha':sha,'ct':content_type,'sz':len(data)})
+    s.execute(sql('INSERT INTO files(owner_email,label,folder,s3_key,sha256,content_type,size_bytes,approved,version) VALUES (:e,:l,:folder,:k,:sha,:ct,:sz,0,1)'),
+              {'e':email,'l':label,'folder':folder,'k':key,'sha':sha,'ct':content_type,'sz':len(data)})
     s.commit()
     file_id=s.execute(sql('SELECT last_insert_rowid()')).scalar()
     return jsonify({'ok':True,'id':file_id,'key':key})

--- a/P4-vault/assetarc-vault/app.py
+++ b/P4-vault/assetarc-vault/app.py
@@ -46,8 +46,8 @@ def upload():
     key=f"{email}/{folder}/{int(datetime.utcnow().timestamp())}_{f.filename}"
     put_object(key, data, content_type)
     s=Session()
-    s.execute(sql('INSERT INTO files(owner_email,label,folder,s3_key,sha256,content_type,size_bytes,approved,version) VALUES (:e,:l,:fo,:k,:sha,:ct,:sz,0,1)'),
-              {'e':email,'l':label,'fo':folder,'k':key,'sha':sha,'ct':content_type,'sz':len(data)})
+    s.execute(sql('INSERT INTO files(owner_email,label,folder,s3_key,sha256,content_type,size_bytes,approved,version) VALUES (:e,:l,:folder,:k,:sha,:ct,:sz,0,1)'),
+              {'e':email,'l':label,'folder':folder,'k':key,'sha':sha,'ct':content_type,'sz':len(data)})
     s.commit()
     file_id=s.execute(sql('SELECT last_insert_rowid()')).scalar()
     return jsonify({'ok':True,'id':file_id,'key':key})


### PR DESCRIPTION
## Summary
- replace `:fo` with `:folder` in file insert statements
- align parameter dictionaries with `folder` key

## Testing
- `flake8 --select=F P04-vault/assetarc-vault/app.py P4-vault/assetarc-vault/app.py`
- `rg -n ':fo\b' P04-vault/assetarc-vault/app.py P4-vault/assetarc-vault/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68a05aff26988321a7caccde01d5cdb6