### PR TITLE
Fix CREATE TABLE syntax in booking and docgen DB initializers

### DIFF
--- a/P08-booking/assetarc-booking/db.py
+++ b/P08-booking/assetarc-booking/db.py
@@ -1,20 +1,25 @@
-
 import os
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
-DB_URL=os.getenv('BOOK_DB_URL','sqlite:///assetarc_booking.db')
-_engine=create_engine(DB_URL, future=True)
-Session=sessionmaker(bind=_engine, expire_on_commit=False)
+
+DB_URL = os.getenv('BOOK_DB_URL', 'sqlite:///assetarc_booking.db')
+_engine = create_engine(DB_URL, future=True)
+Session = sessionmaker(bind=_engine, expire_on_commit=False)
+
+
 def init_db():
     with _engine.begin() as c:
-        c.execute(text('''CREATE TABLE IF NOT EXISTS entitlements (
+        c.execute(text("""CREATE TABLE IF NOT EXISTS entitlements (
             email TEXT PRIMARY KEY,
             credits INTEGER NOT NULL DEFAULT 0,
-            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP)'''))
-        c.execute(text('''CREATE TABLE IF NOT EXISTS events (
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )"""))
+        c.execute(text("""CREATE TABLE IF NOT EXISTS events (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             calendly_event TEXT,
             invitee_email TEXT,
             status TEXT,
             payload TEXT,
-            created_at DATETIME DEFAULT CURRENT_TIMESTAMP)'''))
+            created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )"""))
+

--- a/P10-docgen/assetarc-docgen/db.py
+++ b/P10-docgen/assetarc-docgen/db.py
@@ -1,20 +1,20 @@
-
 import os
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import sessionmaker
 
-DB_URL=os.getenv('DOCGEN_DB_URL','sqlite:///assetarc_docgen.db')
-_engine=create_engine(DB_URL, future=True)
-Session=sessionmaker(bind=_engine, expire_on_commit=False)
+DB_URL = os.getenv('DOCGEN_DB_URL', 'sqlite:///assetarc_docgen.db')
+_engine = create_engine(DB_URL, future=True)
+Session = sessionmaker(bind=_engine, expire_on_commit=False)
+
 
 def init_db():
     with _engine.begin() as c:
-        c.execute(text('''CREATE TABLE IF NOT EXISTS credits(
+        c.execute(text("""CREATE TABLE IF NOT EXISTS credits (
             email TEXT PRIMARY KEY,
             amount INTEGER NOT NULL DEFAULT 0,
             updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
-        )'''))
-        c.execute(text('''CREATE TABLE IF NOT EXISTS renders(
+        )"""))
+        c.execute(text("""CREATE TABLE IF NOT EXISTS renders (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             email TEXT,
             template_id TEXT,
@@ -22,4 +22,5 @@ def init_db():
             output_name TEXT,
             s3_key TEXT,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
-        )'''))
+        )"""))
+


### PR DESCRIPTION
## Summary
- fix SQL table creation statements for booking and docgen services
- ensure `CREATE TABLE IF NOT EXISTS` statements are well-formed

## Testing
- `cd P08-booking/assetarc-booking && python - <<'PY'
from db import init_db
init_db()
print('init done')
PY`
- `cd P10-docgen/assetarc-docgen && python - <<'PY'
from db import init_db
init_db()
print('init done')
PY`
- `pytest P08-booking/assetarc-booking/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a05c51774083218c291e0c77a04378