### PR TITLE
Add Vault/Docs bridges and flag review settings

### DIFF
--- a/P06-gateway-full/assetarc-gateway/.env.example
+++ b/P06-gateway-full/assetarc-gateway/.env.example
@@ -1,0 +1,10 @@
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+JWT_SECRET=changeme
+
+AUTH_BASE=http://localhost:5001
+LLM_BASE=http://localhost:5002
+FX_BASE=http://localhost:5003
+PAY_BASE=http://localhost:5011
+BOOKING_BASE=http://localhost:5012
+VAULT_BASE=http://localhost:5014
+DOCS_BASE=http://localhost:5015

--- a/P06-gateway-full/assetarc-gateway/README.md
+++ b/P06-gateway-full/assetarc-gateway/README.md
@@ -2,25 +2,30 @@
 # AssetArc Gateway (Flask API Bridge)
 
 Single entrypoint that:
+
 - Verifies sessions (shares JWT secret with Auth).
 - Proxies/aggregates calls to downstream services (Auth, FX, LLM, Payments, Booking, Vault, Docs).
 - Centralizes CORS and cookie handling so web UIs (WordPress/app) only talk to the gateway.
 
 ## Endpoints (starter set)
+
 - `GET  /healthz` – health probe
 - `GET  /user` – current user (from cookie/JWT)
 - `GET  /bridge/fx/latest` – pass-through to FX service
 - `POST /bridge/payments/create-invoice/nowpayments` – pass-through to Payments
 - `GET  /bridge/booking/availability` – read availability from Booking (if enabled)
 - `POST /bridge/llm/generate` – pass-through to LLM layer
+- `/bridge/vault/*` – generic pass-through to Vault service
+- `/bridge/docs/*` – generic pass-through to Docs service
 
 > Extend `service_client.py` to add more bridges with identical auth/cookie behavior.
 
 ## Quickstart
+
 1) `cp .env.example .env` and fill service base URLs + CORS + JWT.
 2) `pip install -r requirements.txt`
 3) `flask --app app.py run --host 0.0.0.0 --port 5010 --debug`
 
 ## Deploy
-- Docker (Dockerfile + docker-compose.yml) or systemd + Gunicorn behind Nginx (`nginx/assetarc-gateway.conf`).
 
+- Docker (Dockerfile + docker-compose.yml) or systemd + Gunicorn behind Nginx (`nginx/assetarc-gateway.conf`).

--- a/P06-gateway-full/assetarc-gateway/app.py
+++ b/P06-gateway-full/assetarc-gateway/app.py
@@ -17,6 +17,8 @@ LLM=os.getenv('LLM_BASE','http://localhost:5002')
 FX =os.getenv('FX_BASE','http://localhost:5003')
 PAY=os.getenv('PAY_BASE','http://localhost:5011')
 BOOK=os.getenv('BOOKING_BASE','http://localhost:5012')
+VAULT=os.getenv('VAULT_BASE','http://localhost:5014')
+DOCS =os.getenv('DOCS_BASE','http://localhost:5015')
 
 @app.get('/healthz')
 def health(): return jsonify({'ok':True})
@@ -59,6 +61,24 @@ def b_booking_avail():
 @require_auth
 def b_llm_generate():
     return forward_json(LLM, 'POST', "/llm/generate", request.get_json(force=True))
+
+# -------- Bridge: Vault --------
+@app.route('/bridge/vault/<path:path>', methods=['GET','POST','PUT','DELETE','PATCH'])
+@require_auth
+def b_vault(path):
+    method=request.method
+    body=request.get_json(force=True, silent=True) if method in ('POST','PUT','PATCH') else None
+    qs=('?' + request.query_string.decode()) if request.query_string else ''
+    return forward_json(VAULT, method, f'/{path}{qs}', body)
+
+# -------- Bridge: Docs --------
+@app.route('/bridge/docs/<path:path>', methods=['GET','POST','PUT','DELETE','PATCH'])
+@require_auth
+def b_docs(path):
+    method=request.method
+    body=request.get_json(force=True, silent=True) if method in ('POST','PUT','PATCH') else None
+    qs=('?' + request.query_string.decode()) if request.query_string else ''
+    return forward_json(DOCS, method, f'/{path}{qs}', body)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=int(os.getenv('PORT','5010')), debug=os.getenv('FLASK_ENV')=='development')

--- a/P10-docgen/assetarc-docgen/.env.example
+++ b/P10-docgen/assetarc-docgen/.env.example
@@ -1,0 +1,10 @@
+CORS_ALLOWED_ORIGINS=http://localhost:3000
+JWT_SECRET=changeme
+
+REVIEW_BASE=http://localhost:5009
+REVIEW_BEARER=changeme
+
+ENTITLEMENT_REQUIRED=True
+TOKENS_BASE=
+VAULT_PREFIX_PATTERN={email}/{yyyy}/{mm}/
+CONSUME_REASON=docgen_final

--- a/P10-docgen/assetarc-docgen/README.md
+++ b/P10-docgen/assetarc-docgen/README.md
@@ -4,29 +4,39 @@
 Fully copy‑pasteable service to generate DOCX/PDF outputs, with optional **entitlement check** before final rendering, **Vault alignment** (S3 prefixes), and **Review‑Flag ping** to the Review Queue (P9).
 
 ## Endpoints
+
 - `GET  /healthz`
 - `GET  /templates` – list available docx/html templates
 - `POST /generate/docx` – `{template_id, values, output_name, consume_token?}`
 - `POST /generate/pdf`  – `{template_id, values, output_name, consume_token?}`
 - `POST /approve-upload` – same body + uploads final to S3 using Vault prefixes
-- `POST /flag` – `{level, reason, submission_id?}` forwards to Review service (P9)
+- `POST /flag` – `{level, reason, submission_id?}` forwards to Review service (P9); requires `REVIEW_BASE` and `REVIEW_BEARER`
+
+## Review flag setup
+
+Set `REVIEW_BASE` to the Review Queue service URL and `REVIEW_BEARER` to a bearer token allowed to create flags.
 
 ## Entitlements (optional)
+
 Set `ENTITLEMENT_REQUIRED=True` to block **final** renders unless the user has a credit/token.
+
 - If `TOKENS_BASE` is set: we check `/tokens/balance?email=` and optionally `POST /tokens/consume`.
 - If not set: we fall back to a local `credits` table (`POST /credits/grant {email,amount}` to grant).
 
 ## Vault alignment
+
 - Direct S3 upload using AWS creds, or call your P4 service if you prefer. This pack writes to S3 directly for simplicity.
 - Key pattern is configurable with `VAULT_PREFIX_PATTERN` (default: `{email}/{yyyy}/{mm}/`).
 - File metadata includes `x-amz-meta-docgen: true` and `x-amz-meta-template-id`.
 
 ## Quickstart
+
 1) `cp .env.example .env` and fill values.
 2) `pip install -r requirements.txt`
 3) `python -c "from db import init_db; init_db()"`
 4) `flask --app app.py run --host 0.0.0.0 --port 5010 --debug`
 
 ## Notes
+
 - DOCX: simple `{{PLACEHOLDER}}` replacements in paragraphs & tables (no complex logic). For loops/conditions, render via PDF (Jinja2 → HTML → PDF).
 - PDF: WeasyPrint renders HTML templates with Jinja2 variables; requires system libs (see Dockerfile).

--- a/P10-docgen/assetarc-docgen/app.py
+++ b/P10-docgen/assetarc-docgen/app.py
@@ -136,17 +136,17 @@ class FlagBody(BaseModel):
 @require_auth
 def flag():
     base=os.getenv('REVIEW_BASE','').strip()
-    if not base:
-        return jsonify({'ok':False,'error':'REVIEW_BASE not set'}),400
+    bearer=os.getenv('REVIEW_BEARER','').strip()
+    if not base or not bearer:
+        return jsonify({'ok':False,'error':'REVIEW_BASE and REVIEW_BEARER required'}),400
     try:
         b=FlagBody(**request.get_json(force=True))
     except ValidationError as e:
         return jsonify({'ok':False,'error':e.errors()}),400
     import requests
-    headers={'Content-Type':'application/json'}
-    rb=os.getenv('REVIEW_BEARER','').strip()
-    if rb: headers['Authorization']=f'Bearer {rb}'
-    r=requests.post(base.rstrip('/')+'/flags', headers=headers, json={'submission_id': b.submission_id or 0, 'level': b.level, 'reason': b.reason}, timeout=6)
+    headers={'Content-Type':'application/json', 'Authorization': f'Bearer {bearer}'}
+    r=requests.post(base.rstrip('/')+'/flags', headers=headers,
+                    json={'submission_id': b.submission_id or 0, 'level': b.level, 'reason': b.reason}, timeout=6)
     if r.status_code==200:
         return jsonify({'ok':True})
     return jsonify({'ok':False,'status':r.status_code,'resp': r.text}),502


### PR DESCRIPTION
## Summary
- implement generic Vault and Docs bridge routes in gateway
- document and enforce REVIEW_BASE/REVIEW_BEARER for docgen flag endpoint
- add example environment files for gateway and docgen

## Testing
- `python -m py_compile P06-gateway-full/assetarc-gateway/app.py P10-docgen/assetarc-docgen/app.py`
- `npx --yes markdownlint-cli P06-gateway-full/assetarc-gateway/README.md P10-docgen/assetarc-docgen/README.md` *(line-length warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a05fd468748321bfe9c5117d5deeb5