### PR TITLE
fix: capitalize PyYAML in compose generator

### DIFF
--- a/scripts/gen-compose.py
+++ b/scripts/gen-compose.py
@@ -142,7 +142,7 @@ if __name__ == "__main__":
         import yaml  # type: ignore
     except Exception:
         print(
-            "ERROR: pyyaml not available in your host Python. Install with: pip install pyyaml"
+            "ERROR: PyYAML not available in your host Python. Install with: pip install pyyaml"
         )
         sys.exit(1)
     main()


### PR DESCRIPTION
## Summary
- fix PyYAML capitalization in missing dependency error message

## Testing
- `flake8 scripts/gen-compose.py` *(fails: E501 line too long, E302 expected 2 blank lines, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a06880932483219dc8ca00109dac9f