### PR TITLE
fix: ensure gunicorn is installed in service images

### DIFF
--- a/P1-auth/assetarc-auth/Dockerfile
+++ b/P1-auth/assetarc-auth/Dockerfile
@@ -4,7 +4,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir gunicorn
 COPY . .
 RUN useradd -m appuser
 USER appuser

--- a/P1-auth/assetarc-auth/requirements.txt
+++ b/P1-auth/assetarc-auth/requirements.txt
@@ -6,3 +6,4 @@ PyJWT==2.8.0
 boto3==1.34.158
 python-dotenv==1.0.1
 email-validator==2.1.1
+gunicorn==21.2.0

--- a/P2-llm/assetarc-llm/Dockerfile
+++ b/P2-llm/assetarc-llm/Dockerfile
@@ -4,7 +4,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir gunicorn
 COPY . .
 RUN useradd -m appuser
 USER appuser

--- a/P2-llm/assetarc-llm/requirements.txt
+++ b/P2-llm/assetarc-llm/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.0.2
 Flask-Cors==4.0.1
 python-dotenv==1.0.1
 openai==1.35.10
+gunicorn==21.2.0

--- a/P3-fx/assetarc-fx/Dockerfile
+++ b/P3-fx/assetarc-fx/Dockerfile
@@ -4,7 +4,8 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir gunicorn
 COPY . .
 RUN useradd -m appuser
 USER appuser

--- a/P3-fx/assetarc-fx/requirements.txt
+++ b/P3-fx/assetarc-fx/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.0.2
 Flask-Cors==4.0.1
 requests==2.32.3
 python-dotenv==1.0.1
+gunicorn==21.2.0

--- a/P4-vault/assetarc-vault/Dockerfile
+++ b/P4-vault/assetarc-vault/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir gunicorn
 COPY . .
 EXPOSE 5014
 CMD ["gunicorn","-b","0.0.0.0:5014","-w","3","app:app"]

--- a/P4-vault/assetarc-vault/requirements.txt
+++ b/P4-vault/assetarc-vault/requirements.txt
@@ -8,3 +8,4 @@ pydantic==2.8.2
 Pillow==10.3.0
 PyPDF2==3.0.1
 reportlab==4.2.2
+gunicorn==21.2.0

--- a/P6-gateway-full/assetarc-gateway/Dockerfile
+++ b/P6-gateway-full/assetarc-gateway/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir gunicorn
 COPY . .
 EXPOSE 5010
 CMD ["gunicorn","-b","0.0.0.0:5010","-w","3","app:app"]

--- a/P6-gateway-full/assetarc-gateway/requirements.txt
+++ b/P6-gateway-full/assetarc-gateway/requirements.txt
@@ -4,3 +4,4 @@ python-dotenv==1.0.1
 PyJWT==2.8.0
 requests==2.32.3
 pydantic==2.8.2
+gunicorn==21.2.0

--- a/P7-payments/assetarc-payments/Dockerfile
+++ b/P7-payments/assetarc-payments/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.11-slim
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends libffi-dev libcairo2 pango1.0-tools libjpeg62-turbo libpng16-16 && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir gunicorn
 COPY . .
 EXPOSE 5007
 CMD ["gunicorn","-b","0.0.0.0:5007","-w","3","app:app"]

--- a/P7-payments/assetarc-payments/requirements.txt
+++ b/P7-payments/assetarc-payments/requirements.txt
@@ -8,3 +8,4 @@ pydantic==2.8.2
 WeasyPrint==62.3
 Jinja2==3.1.4
 boto3==1.34.158
+gunicorn==21.2.0

--- a/P8-booking/assetarc-booking/Dockerfile
+++ b/P8-booking/assetarc-booking/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir gunicorn
 COPY . .
 EXPOSE 5012
 CMD ["gunicorn","-b","0.0.0.0:5012","-w","3","app:app"]

--- a/P8-booking/assetarc-booking/requirements.txt
+++ b/P8-booking/assetarc-booking/requirements.txt
@@ -9,3 +9,4 @@ python-dateutil==2.9.0.post0
 google-api-python-client==2.137.0
 google-auth==2.34.0
 google-auth-httplib2==0.2.0
+gunicorn==21.2.0

--- a/P9-review/assetarc-review/Dockerfile
+++ b/P9-review/assetarc-review/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir gunicorn
 COPY . .
 EXPOSE 5016
 CMD ["gunicorn","-b","0.0.0.0:5016","-w","3","app:app"]


### PR DESCRIPTION
## Summary
- add gunicorn dependency to auth, llm, fx, vault, gateway, payments, and booking services
- install gunicorn within Dockerfiles for auth, llm, fx, vault, gateway, payments, booking, and review services

## Testing
- `pytest` *(fails: import file mismatch error)*

------
https://chatgpt.com/codex/tasks/task_e_68a09555529483219141cbe7b18dcd21